### PR TITLE
used paths from results instead

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,30 @@
 import OpenAI from 'openai';
-import path from 'path';
 import fs from 'fs';
+import * as readline from "readline";
 
 const openai = new OpenAI({
     apiKey: 'your openai key',
 });
 
-export async function cypressAI(result: any) {
-    if ('status' in result) return;
+function isCypressFailedRunResult(
+    result: CypressCommandLine.CypressRunResult | CypressCommandLine.CypressFailedRunResult
+  ): result is CypressCommandLine.CypressFailedRunResult {
+    return "status" in result;
+  }
+
+export async function cypressAI(result: CypressCommandLine.CypressRunResult | CypressCommandLine.CypressFailedRunResult) {
+    if (isCypressFailedRunResult(result)) return;
+    if (result.totalFailed === 0) return;
 
     await Promise.all(
         result.runs.map((run) => {
-            const specPath = path.join(
-                __dirname,
-                './cypress/e2e',
-                `${run.spec.fileName}.cy${run.spec.fileExtension}`
-            );
-            console.log(specPath);
-            const specFile: string = fs.readFileSync(specPath).toString();
-
             return Promise.all(
                 run.tests.map(async (test) => {
                     if (test.state === 'passed') return;
-                    const screenshotPath = path.join(
-                        __dirname,
-                        './cypress/screenshots',
-                        'spec.cy.ts',
-                        `${test.title[0]} -- ${test.title[1]} (failed).png`
-                    );
+                    const screenshotFile = fs.readFileSync(run.screenshots[0].path);
+                    const screenshotBase64 = screenshotFile.toString("base64");
 
-                    const screenshotFile = fs.readFileSync(screenshotPath);
-                    const screenshotBase64 = screenshotFile.toString('base64');
-
+                    const twirlTimer = createSpinner();
                     const chatCompletion = await openai.chat.completions.create(
                         {
                             messages: [
@@ -40,7 +33,7 @@ export async function cypressAI(result: any) {
                                     content: [
                                         {
                                             type: 'text',
-                                            text: `I have a Cypress test failure with the following error: ${test.displayError}. Here is my spec file: ${specFile} Can you provide general advice on what could be wrong and how to troubleshoot this type of error? Please keep your answer short and concise. This will be used for the error output in a users terminal.`,
+                                            text: `I have a Cypress test failure with the following error: ${test.displayError}. Here is my spec file: ${run.spec.absolute} Can you provide general advice on what could be wrong and how to troubleshoot this type of error? Please keep your answer short and concise. This will be used for the error output in a users terminal.`,
                                         },
                                         {
                                             type: 'image_url',
@@ -55,11 +48,38 @@ export async function cypressAI(result: any) {
                         }
                     );
 
-                    chatCompletion.choices.map((choice) =>
-                        console.log(choice.message.content)
-                    );
-                })
-            );
+                    clearSpinner(twirlTimer);
+
+                    console.log(`
+==============================
+
+[Specfile]: ${run.spec.absolute}
+
+[Error]: ${test.displayError}
+
+[Suggested solutions]: 
+`);
+          chatCompletion.choices.forEach((choice) => {
+            console.log(`\x1b[33m ${choice.message.content} \x1b[0m`);
+            console.log("\r");
+          });
         })
-    );
+      );
+    })
+  );
 }
+
+function createSpinner() {
+    const P = ["\\", "|", "/", "-"];
+    let x = 0;
+    return setInterval(function () {
+      process.stdout.write(`\r  generating solutions ${P[x++]}`);
+      x &= 3;
+    }, 250);
+  }
+  
+  function clearSpinner(ref: NodeJS.Timeout) {
+    clearInterval(ref);
+    readline.clearLine(process.stdout, 0);
+  }
+  


### PR DESCRIPTION
- removed :any from results
- used the absolute paths provided by cypress instead of the resolved ones
- created a spinner to better indicate that an api call is being called
- formatted outputs and made them yellow